### PR TITLE
RD-2204: Allow bbh-maven-plugin to support all valid OSGi versions

### DIFF
--- a/src/it/no-minor-it/pom.xml
+++ b/src/it/no-minor-it/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2015 Basis Technology Corp.
+ 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+ 
+         http://www.apache.org/licenses/LICENSE-2.0
+ 
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.basistech.bbh.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>osgi-version</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>osgi-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0-alpha-2</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/app.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/no-minor-it/verify.groovy
+++ b/src/it/no-minor-it/verify.groovy
@@ -1,0 +1,14 @@
+Properties properties = new Properties()
+File propertiesFile = new File('target/it/no-minor-it/target/app.properties')
+System.err.println(propertiesFile.getAbsolutePath())
+propertiesFile.withInputStream {
+    properties.load(it)
+}
+
+def runtimeString = 'osgi-version'
+def val = properties."$runtimeString"
+
+def matcher = (val =~ ~/1\.0\.0\.v[0-9]*/)
+assert matcher.matches()
+
+

--- a/src/it/no-patch-it/pom.xml
+++ b/src/it/no-patch-it/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2015 Basis Technology Corp.
+ 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+ 
+         http://www.apache.org/licenses/LICENSE-2.0
+ 
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.basistech.bbh.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.2-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>osgi-version</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>osgi-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0-alpha-2</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/app.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/no-patch-it/verify.groovy
+++ b/src/it/no-patch-it/verify.groovy
@@ -1,0 +1,14 @@
+Properties properties = new Properties()
+File propertiesFile = new File('target/it/no-patch-it/target/app.properties')
+System.err.println(propertiesFile.getAbsolutePath())
+propertiesFile.withInputStream {
+    properties.load(it)
+}
+
+def runtimeString = 'osgi-version'
+def val = properties."$runtimeString"
+
+def matcher = (val =~ ~/1\.2\.0\.v[0-9]*/)
+assert matcher.matches()
+
+

--- a/src/it/non-snapshot-extra-qualifier-it/pom.xml
+++ b/src/it/non-snapshot-extra-qualifier-it/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2015 Basis Technology Corp.
+ 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+ 
+         http://www.apache.org/licenses/LICENSE-2.0
+ 
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.basistech.bbh.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.0.2.qualifier</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>osgi-version</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>osgi-version</goal>
+            </goals>
+            <configuration>
+              <timestampQualifier>true</timestampQualifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0-alpha-2</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/app.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/non-snapshot-extra-qualifier-it/verify.groovy
+++ b/src/it/non-snapshot-extra-qualifier-it/verify.groovy
@@ -1,0 +1,14 @@
+Properties properties = new Properties()
+File propertiesFile = new File('target/it/non-snapshot-extra-qualifier-it/target/app.properties')
+System.err.println(propertiesFile.getAbsolutePath())
+propertiesFile.withInputStream {
+    properties.load(it)
+}
+
+def runtimeString = 'osgi-version'
+def val = properties."$runtimeString"
+
+def matcher = (val =~ ~/1\.0\.2\.qualifier-v[0-9]*/)
+assert matcher.matches()
+
+

--- a/src/it/snapshot-qualifier-it/pom.xml
+++ b/src/it/snapshot-qualifier-it/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2015 Basis Technology Corp.
+ 
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+ 
+         http://www.apache.org/licenses/LICENSE-2.0
+ 
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.basistech.bbh.it</groupId>
+  <artifactId>simple-it</artifactId>
+  <version>1.0.2.qualifier-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>osgi-version</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>osgi-version</goal>
+            </goals>
+            <configuration>
+              <timestampQualifier>true</timestampQualifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0-alpha-2</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.directory}/app.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/snapshot-qualifier-it/verify.groovy
+++ b/src/it/snapshot-qualifier-it/verify.groovy
@@ -1,0 +1,14 @@
+Properties properties = new Properties()
+File propertiesFile = new File('target/it/snapshot-qualifier-it/target/app.properties')
+System.err.println(propertiesFile.getAbsolutePath())
+propertiesFile.withInputStream {
+    properties.load(it)
+}
+
+def runtimeString = 'osgi-version'
+def val = properties."$runtimeString"
+
+def matcher = (val =~ ~/1\.0\.2\.qualifier-v[0-9]*/)
+assert matcher.matches()
+
+


### PR DESCRIPTION
The OSGi spec allows for qualifiers to go at the end of versions. This PR allows the BBH plugin to do the same. Additionally, this patch also makes the inclusion of minor and patch numbers optional for non-cXX.Y versions. Here is an example of it in action:
```
(same as before)
1.2.3-SNAPSHOT --> 1.2.3.20171213090923
1.2.3.c59.0-SNAPSHOT --> 1.2.3.20171213090923 [Note: this qualifier is special (it's the only one we allow a period to be in)]
1.2.3 --> 1.2.3
1.2.3.c59.0 --> 1.2.3
(new behavior)
1.2.3.my_qualifier_4-SNAPSHOT  --> 1.2.3.my_qualifier_4-20171213090923
1-SNAPSHOT --> 1.0.0.20171213090923
1.2-SNAPSHOT --> 1.2.0.20171213090923
1.2.3.my_qualifier_4 --> 1.2.3.my_qualifier_4
1 --> 1.0.0
1.2 --> 1.2.0
```